### PR TITLE
Add an option to filter contacts

### DIFF
--- a/Pod/Classes/EVContactsPickerDelegate.swift
+++ b/Pod/Classes/EVContactsPickerDelegate.swift
@@ -10,4 +10,6 @@ import Foundation
 
 @objc public protocol EVContactsPickerDelegate : NSObjectProtocol {
     func didChooseContacts(contacts: [EVContact]? ) -> Void
+    
+    optional func shouldShowContact(contact: EVContact) -> Bool
 }

--- a/Pod/Classes/EVContactsPickerViewController.swift
+++ b/Pod/Classes/EVContactsPickerViewController.swift
@@ -185,7 +185,12 @@ import ContactsUI
                     tmpContact.image = im
                 }
                 
-                mutableContacts.append(tmpContact)
+                let showContact = self.delegate?.shouldShowContact?(tmpContact)
+                
+                if showContact == nil || showContact == true {
+                    mutableContacts.append(tmpContact)
+                }
+                
                 self.contacts = mutableContacts
                 self.selectedContacts = []
                 self.filteredContacts = self.contacts


### PR DESCRIPTION
This pull request adds new optional delegate method `optional func shouldShowContact(contact: EVContact) -> Bool`. This allows client to filter contacts, it useful in some case e.g. when you want to show only people with phone numbers to send them SMS.
